### PR TITLE
Always fetching SEO tags

### DIFF
--- a/lib/dato_cms_graphql/graphql_base.rb
+++ b/lib/dato_cms_graphql/graphql_base.rb
@@ -60,6 +60,12 @@ module DatoCmsGraphql
           <<~GRAPHQL
             #{locale}_items: all#{plural_name}(locale: #{locale}, fallbackLocales: [#{I18n.default_locale}], first: #{graphql_page_size}, skip: $skip) {
               #{fields}
+
+              _seoMetaTags {
+                tag
+                content
+                attributes
+              }
             }
           GRAPHQL
         end
@@ -76,6 +82,12 @@ module DatoCmsGraphql
           <<~GRAPHQL
             #{locale}_item: #{single_name}(locale: #{locale}, fallbackLocales: [#{I18n.default_locale}]) {
               #{fields}
+
+              _seoMetaTags {
+                tag
+                content
+                attributes
+              }
             }
           GRAPHQL
         end

--- a/lib/test_schema.rb
+++ b/lib/test_schema.rb
@@ -9,9 +9,16 @@ class TestSchema < GraphQL::Schema
     end
   end
 
+  class TagType < GraphQL::Schema::Object
+    field :tag, String, null: true
+    field :content, String, null: true
+    field :attributes, String, null: true
+  end
+
   class PersonType < GraphQL::Schema::Object
     field :id, String, null: true
     field :name, String, null: true
+    field :_seo_meta_tags, [TagType], null: false
   end
 
   class MetaType < GraphQL::Schema::Object
@@ -42,7 +49,8 @@ class TestSchema < GraphQL::Schema
     def all_under_tests
       OpenStruct.new(
         id: "test",
-        name: "Stan"
+        name: "Stan",
+        _seo_meta_tags: []
       )
     end
   end


### PR DESCRIPTION
These seem to always exist, regardless of the actual schema. I'm not sure how they're computed, or if it's really what we need, but they seem pretty good.

Adding them implicitly to all queries doesn't seem to affect build times, and to me it seems nicer than having to specify this stuff everywhere in every project.

I guess we _could_ add some configs to opt in/out of this, though 🤔 