### PR TITLE
Optional API key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dato_cms_graphql (0.2.3)
+    dato_cms_graphql (0.2.4)
       activesupport (~> 7.1.3)
       graphql-client (~> 0.19.0)
 

--- a/lib/dato_cms_graphql/base_query.rb
+++ b/lib/dato_cms_graphql/base_query.rb
@@ -46,7 +46,7 @@ module DatoCmsGraphql
       end
 
       def parse(query)
-        DatoCmsGraphql::Client.parse(query)
+        DatoCmsGraphql::Client.parse(query) if defined?(DatoCmsGraphql::Client)
       end
 
       def query_for


### PR DESCRIPTION
Only parsing queries if the client exists.

The point is that the client exists only if it _can_ exist -- i.e. if we're in test or we have a proper API Key.

If it doesn't we're still getting the log message about missing keys, and `parse` won't do anything. This obviously means that nothing will work, but it will only break stuff when we actually try to use the query results rather than at start up.

So, other things that don't really care about the data (e.g. rake tasks or whatever) will still start and be fine as long as they don't use the Graph models.