### PR TITLE
Bump version number and update Rails persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.0] - 2026-01-13
+
+- Update gem to support Rails 8 for improved compatibility
+- Add documentation enhancements and usage examples in AGENTS.md
+- Update tests and documentation for better coverage and onboarding
+- Fix warnings in tests related to string handling and deprecations
+- Bump supported Ruby versions for broader compatibility
+- Require ostruct as a runtime dependency for Ruby 3.4+ stdlib compatibility
+- Clear out unnecessary extra slashes in query paths
+
 ## [0.2.8] - 2025-12-17
 
 - Add ostruct and logger as runtime dependencies for Ruby 3.4+ stdlib compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dato_cms_graphql (0.2.8)
+    dato_cms_graphql (0.3.0)
       activesupport (>= 7.1, < 9.0)
       graphql-client (>= 0.24.0, < 1.0)
       logger

--- a/lib/dato_cms_graphql/rails/railtie.rb
+++ b/lib/dato_cms_graphql/rails/railtie.rb
@@ -5,8 +5,10 @@ module DatoCmsGraphql
         load File.join(__dir__, "cache_task.rake")
       end
       initializer "dato_cms_graphql_railtie.configure_rails_initialization" do |app|
-        DatoCmsGraphql.path_to_queries = app.root.join("app", "queries")
-        puts DatoCmsGraphql.path_to_queries
+        unless ENV["TEST"] == "true"
+          DatoCmsGraphql.path_to_queries = app.root.join("app", "queries")
+          puts DatoCmsGraphql.path_to_queries
+        end
       end
     end
   end

--- a/lib/dato_cms_graphql/version.rb
+++ b/lib/dato_cms_graphql/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatoCmsGraphql
-  VERSION = "0.2.8"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Rails 8 was having trouble with the existing find_or_create_by methodology. Being a bit more explicit regarding what we are doing.